### PR TITLE
fix: handle missing Lagoon env var variables

### DIFF
--- a/common.go
+++ b/common.go
@@ -83,7 +83,11 @@ func LagoonBuildVars() (map[string]string, error) {
 		// read variables from environment
 		varsJSON, ok := os.LookupEnv(envVar)
 		if !ok {
-			return nil, fmt.Errorf("couldn't find %s in environment", envVar)
+			// variable is not set in process environment.
+			// this is OK because these variables are optional. see:
+			// https://github.com/amazeeio/lagoon-kbd/blob/main/
+			// 	controllers/lagoonbuild_controller.go
+			continue
 		}
 		// unmarshal JSON
 		var vars []lagoonVar

--- a/common_test.go
+++ b/common_test.go
@@ -121,6 +121,14 @@ func TestLagoonBuildVars(t *testing.T) {
 			main.LagoonProjectVars: `[]`,
 			main.LagoonEnvVars:     `[]`,
 		}, expect: map[string]string{}},
+		"missingEnvironmentVariable0": {input: map[string]string{
+			main.LagoonEnvVars: `[]`,
+		}, expect: map[string]string{}},
+		"missingEnvironmentVariable1": {input: map[string]string{
+			main.LagoonProjectVars: `[]`,
+		}, expect: map[string]string{}},
+		"missingEnvironmentVariable2": {input: map[string]string{},
+			expect: map[string]string{}},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(tt *testing.T) {


### PR DESCRIPTION
As per the code in the lagoon-kbd controller, these variables are not
set on the build pod if they are empty. So we need to handle that
without error.

<!--
IMPORTANT NOTE: Commits must adhere to the conventional commits specification:
https://www.conventionalcommits.org/en/v1.0.0/

Explain the **details** for making this change. What existing problem does the pull request solve?

Put `Closes: #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
-->
