### PR TITLE
Disable CGO in goreleaser builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,3 @@
+builds:
+- env:
+  - CGO_ENABLED=0


### PR DESCRIPTION
The binary needs to be statically linked, so disable CGO.